### PR TITLE
Updated Baubles API.

### DIFF
--- a/src/api/java/baubles/api/BaublesApi.java
+++ b/src/api/java/baubles/api/BaublesApi.java
@@ -6,28 +6,35 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import cpw.mods.fml.common.FMLLog;
 
-
-
 /**
  * @author Azanor
  */
-public class BaublesApi {
-	
+public class BaublesApi 
+{
 	static Method getBaubles;
+	
 	/**
 	 * Retrieves the baubles inventory for the supplied player
 	 */
-	public static IInventory getBaubles(EntityPlayer player) {
+	public static IInventory getBaubles(EntityPlayer player)
+	{
 		IInventory ot = null;
-	    try {
-	        if(getBaubles == null) {
-	            Class fake = Class.forName("baubles.common.lib.PlayerHandler");
+		
+	    try
+	    {
+	        if(getBaubles == null) 
+	        {
+	            Class<?> fake = Class.forName("baubles.common.lib.PlayerHandler");
 	            getBaubles = fake.getMethod("getPlayerBaubles", EntityPlayer.class);
 	        }
+	        
 	        ot = (IInventory) getBaubles.invoke(null, player);
-	    } catch(Exception ex) { 
+	    } 
+	    catch(Exception ex) 
+	    { 
 	    	FMLLog.warning("[Baubles API] Could not invoke baubles.common.lib.PlayerHandler method getPlayerBaubles");
 	    }
+	    
 		return ot;
 	}
 	

--- a/src/api/java/baubles/api/IBauble.java
+++ b/src/api/java/baubles/api/IBauble.java
@@ -5,10 +5,9 @@ import net.minecraft.item.ItemStack;
 
 /**
  * 
- * @author Azanor
- * 
  * This interface should be extended by items that can be worn in bauble slots
- *
+ * 
+ * @author Azanor
  */
 
 public interface IBauble {

--- a/src/api/java/baubles/api/package-info.java
+++ b/src/api/java/baubles/api/package-info.java
@@ -1,4 +1,4 @@
-@API(owner = "Baubles", apiVersion = baubles.common.Baubles.VERSION, provides = "Baubles|API")
+@API(owner = "Baubles", apiVersion = "1.0.1.10", provides = "Baubles|API")
 package baubles.api;
 
 import cpw.mods.fml.common.API;

--- a/src/main/java/fox/spiteful/forbidden/FMEventHandler.java
+++ b/src/main/java/fox/spiteful/forbidden/FMEventHandler.java
@@ -3,7 +3,7 @@ package fox.spiteful.forbidden;
 import java.util.*;
 
 import WayofTime.alchemicalWizardry.api.soulNetwork.SoulNetworkHandler;
-import baubles.common.lib.PlayerHandler;
+import baubles.api.BaublesApi;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.gameevent.PlayerEvent.ItemCraftedEvent;
 import fox.spiteful.forbidden.blocks.ForbiddenBlocks;
@@ -367,8 +367,8 @@ public class FMEventHandler {
                 ent.motionX += (randy.nextFloat() - randy.nextFloat()) * 0.1F;
                 ent.motionZ += (randy.nextFloat() - randy.nextFloat()) * 0.1F;
             }
-            ItemStack ring = PlayerHandler.getPlayerBaubles(event.entityPlayer).getStackInSlot(1);
-            ItemStack ring2 = PlayerHandler.getPlayerBaubles(event.entityPlayer).getStackInSlot(2);
+            ItemStack ring = BaublesApi.getBaubles(event.entityPlayer).getStackInSlot(1);
+            ItemStack ring2 = BaublesApi.getBaubles(event.entityPlayer).getStackInSlot(2);
             if((ring != null && ring.getItem() == ForbiddenItems.ringFood) || (ring2 != null && ring2.getItem() == ForbiddenItems.ringFood)){
                 event.entityPlayer.getFoodStats().addStats(2, 2.0F);
             }
@@ -434,7 +434,7 @@ public class FMEventHandler {
     public void onFeelPain(LivingHurtEvent event){
         if(!Config.noLust && event.ammount > 0 && event.entityLiving instanceof EntityPlayer){
             EntityPlayer player = (EntityPlayer)event.entityLiving;
-            ItemStack amulet = PlayerHandler.getPlayerBaubles(player).getStackInSlot(0);
+            ItemStack amulet = BaublesApi.getBaubles(player).getStackInSlot(0);
             if(amulet != null && amulet.getItem() == ForbiddenItems.subCollar){
                 int doses = 3 * (int)event.ammount;
                 if(event.source.getEntity() != null && event.source.getEntity() instanceof EntityPlayer){

--- a/src/main/java/fox/spiteful/forbidden/items/baubles/ItemSubCollar.java
+++ b/src/main/java/fox/spiteful/forbidden/items/baubles/ItemSubCollar.java
@@ -1,6 +1,6 @@
 package fox.spiteful.forbidden.items.baubles;
 
-import baubles.common.lib.PlayerHandler;
+import baubles.api.BaublesApi;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import fox.spiteful.forbidden.Forbidden;
@@ -99,7 +99,7 @@ public class ItemSubCollar extends ItemAmuletVis {
         if (entity instanceof EntityPlayer)
         {
             EntityPlayer sub = (EntityPlayer)entity;
-            IInventory baubles = PlayerHandler.getPlayerBaubles(sub);
+            IInventory baubles = BaublesApi.getBaubles(sub);
             if(baubles.getStackInSlot(0) == null) {
                 if(!itemstack.hasTagCompound()){
                     NBTTagCompound tag = new NBTTagCompound();


### PR DESCRIPTION
This PR updates the Baubles API to 1.0.1.10. This fixes the mod not compiling when putting the latest Baubles jar in the 'lib' directory. With these changes the Baubles jar is no longer needed in the 'lib' directory. 